### PR TITLE
Improve precursor mz determination for raw files

### DIFF
--- a/Morpheus/Morpheus/Constants.cs
+++ b/Morpheus/Morpheus/Constants.cs
@@ -2,7 +2,7 @@
 {
     public static class Constants
     {
-        public const double PROTON_MASS = 1.00727638;
+        public const double PROTON_MASS = 1.007276466879;
         public const double C12_C13_MASS_DIFFERENCE = 1.0033548378;
         public const double WATER_MONOISOTOPIC_MASS = 18.0105646942;
         public const double WATER_AVERAGE_MASS = 18.01528;

--- a/Morpheus/Thermo/TandemMassSpectra.Thermo.cs
+++ b/Morpheus/Thermo/TandemMassSpectra.Thermo.cs
@@ -33,7 +33,7 @@ namespace Morpheus
             raw.SetCurrentController(0, 1);
 
             Dictionary<int, double[,]> ms1s;
-            if(REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
+            if (REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
             {
                 ms1s = new Dictionary<int, double[,]>();
             }
@@ -74,14 +74,14 @@ namespace Morpheus
                     GetPrecursor(ms1s, raw, scan_number, scan_filter, first_scan_number, out precursor_mz, out precursor_intensity);
 
                     int charge = DeterminePrecursorCharge(raw, scan_number);
-                    if(polarity < 0)
+                    if (polarity < 0)
                     {
                         charge = -charge;
                     }
 
                     double[,] label_data = GetFragmentationData(raw, scan_number, scan_filter);
                     List<MSPeak> peaks = new List<MSPeak>(label_data.GetLength(1));
-                    for(int peak_index = label_data.GetLowerBound(1); peak_index <= label_data.GetUpperBound(1); peak_index++)
+                    for (int peak_index = label_data.GetLowerBound(1); peak_index <= label_data.GetUpperBound(1); peak_index++)
                     {
                         peaks.Add(new MSPeak(label_data[(int)RawLabelDataColumn.MZ, peak_index],
                             label_data[(int)RawLabelDataColumn.Intensity, peak_index],
@@ -89,15 +89,15 @@ namespace Morpheus
                     }
 
                     peaks = FilterPeaks(peaks, absoluteThreshold, relativeThresholdPercent, maximumNumberOfPeaks);
-                    if(peaks.Count > 0)
+                    if (peaks.Count > 0)
                     {
-                        for(int c = (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? minimumAssumedPrecursorChargeState : charge);
+                        for (int c = (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? minimumAssumedPrecursorChargeState : charge);
                             c <= (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? maximumAssumedPrecursorChargeState : charge); c++)
                         {
                             double precursor_mass = MSPeak.MassFromMZ(precursor_mz, c);
 
                             TandemMassSpectrum spectrum = new TandemMassSpectrum(rawFilepath, scan_number, spectrum_id, null, retention_time_minutes, fragmentation_method, precursor_mz, precursor_intensity, c, precursor_mass, peaks);
-                            lock(this)
+                            lock (this)
                             {
                                 Add(spectrum);
                             }
@@ -105,11 +105,11 @@ namespace Morpheus
                     }
                 }
 
-                lock(progress_lock)
+                lock (progress_lock)
                 {
                     spectra_processed++;
                     int new_progress = (int)((double)spectra_processed / (last_scan_number - first_scan_number + 1) * 100);
-                    if(new_progress > old_progress)
+                    if (new_progress > old_progress)
                     {
                         OnUpdateProgress(new ProgressEventArgs(new_progress));
                         old_progress = new_progress;
@@ -123,15 +123,15 @@ namespace Morpheus
 
         private static string GetFragmentationMethod(string scanFilter)
         {
-            if(scanFilter.Contains("cid"))
+            if (scanFilter.Contains("cid"))
             {
                 return "collision-induced dissociation";
             }
-            else if(scanFilter.Contains("mpd"))
+            else if (scanFilter.Contains("mpd"))
             {
                 return "infrared multiphoton dissociation";
             }
-            else if(scanFilter.Contains("pqd"))
+            else if (scanFilter.Contains("pqd"))
             {
                 return "pulsed q dissociation";
             }
@@ -140,15 +140,15 @@ namespace Morpheus
             //{
             //    return "negative electron transfer dissociation";
             //}
-            else if(scanFilter.Contains("hcd"))
+            else if (scanFilter.Contains("hcd"))
             {
                 return "high-energy collision-induced dissociation";
             }
-            else if(scanFilter.Contains("ecd"))
+            else if (scanFilter.Contains("ecd"))
             {
                 return "electron capture dissociation";
             }
-            else if(scanFilter.Contains("etd"))
+            else if (scanFilter.Contains("etd"))
             {
                 return "electron transfer dissociation";
             }
@@ -160,16 +160,16 @@ namespace Morpheus
 
         private static void GetPrecursor(IDictionary<int, double[,]> ms1s, IXRawfile5 raw, int scanNumber, string scanFilter, int firstScanNumber, out double mz, out double intensity)
         {
-            if(PRECURSOR_MASS_TYPE == PrecursorMassType.Isolation)
+            if (PRECURSOR_MASS_TYPE == PrecursorMassType.Isolation)
             {
                 mz = GetIsolationMZ(scanFilter);
             }
-            else if(PRECURSOR_MASS_TYPE == PrecursorMassType.Monoisotopic)
+            else if (PRECURSOR_MASS_TYPE == PrecursorMassType.Monoisotopic)
             {
                 mz = -1;
                 raw.GetPrecursorMassForScanNum(scanNumber, 2, ref mz);
             }
-            if(REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
+            if (REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
             {
                 RefineMZestimateAndGetIntensity(ms1s, raw, scanNumber, firstScanNumber, ref mz, out intensity);
             }
@@ -185,7 +185,7 @@ namespace Morpheus
         private static bool RefineMZestimateAndGetIntensity(IDictionary<int, double[,]> ms1s, IXRawfile5 raw, int scanNumber, int firstScanNumber, ref double mz, out double intensity)
         {
             scanNumber--;
-            while(scanNumber >= firstScanNumber)
+            while (scanNumber >= firstScanNumber)
             {
                 // ref parameter initializations
                 string scan_filter = null;
@@ -196,11 +196,11 @@ namespace Morpheus
                 if (MSOrder == 1)
                 {
                     double[,] ms1;
-                    lock(ms1s)
+                    lock (ms1s)
                     {
-                        if(!ms1s.TryGetValue(scanNumber, out ms1))
+                        if (!ms1s.TryGetValue(scanNumber, out ms1))
                         {
-                            if(scan_filter.Contains("FTMS"))
+                            if (scan_filter.Contains("FTMS"))
                             {
                                 object labels_obj = null;
                                 object flags_obj = null;
@@ -226,14 +226,14 @@ namespace Morpheus
 
                     int index = -1;
                     // In the MS1 scan, look at every peak. Find index of the one that is closest in mz value to the input parameter mz
-                    for(int i = ms1.GetLowerBound(1); i <= ms1.GetUpperBound(1); i++)
+                    for (int i = ms1.GetLowerBound(1); i <= ms1.GetUpperBound(1); i++)
                     {
-                        if(index < 0 || Math.Abs(ms1[0, i] - mz) < Math.Abs(ms1[0, index] - mz))
+                        if (index < 0 || Math.Abs(ms1[0, i] - mz) < Math.Abs(ms1[0, index] - mz))
                         {
                             index = i;
                         }
                     }
-                    if(index >= 0)
+                    if (index >= 0)
                     {
                         mz = ms1[0, index];
                         intensity = ms1[1, index];
@@ -257,7 +257,7 @@ namespace Morpheus
         private static double[,] GetFragmentationData(IXRawfile2 raw, int scanNumber, string scanFilter)
         {
             double[,] data;
-            if(scanFilter.Contains("FTMS"))
+            if (scanFilter.Contains("FTMS"))
             {
                 object labels_obj = null;
                 object flags_obj = null;
@@ -279,11 +279,11 @@ namespace Morpheus
 
         private static int DeterminePolarity(string scanFilter)
         {
-            if(scanFilter.Contains(" + "))
+            if (scanFilter.Contains(" + "))
             {
                 return 1;
             }
-            else if(scanFilter.Contains(" - "))
+            else if (scanFilter.Contains(" - "))
             {
                 return -1;
             }
@@ -303,9 +303,9 @@ namespace Morpheus
             string[] trailer_values = (string[])trailer_values_obj;
 
             int charge = -1;
-            for(int trailer_index = trailer_labels.GetLowerBound(0); trailer_index <= trailer_labels.GetUpperBound(0); trailer_index++)
+            for (int trailer_index = trailer_labels.GetLowerBound(0); trailer_index <= trailer_labels.GetUpperBound(0); trailer_index++)
             {
-                if(trailer_labels[trailer_index].StartsWith("Charge"))
+                if (trailer_labels[trailer_index].StartsWith("Charge"))
                 {
                     charge = int.Parse(trailer_values[trailer_index]);
                 }

--- a/Morpheus/Thermo/TandemMassSpectra.Thermo.cs
+++ b/Morpheus/Thermo/TandemMassSpectra.Thermo.cs
@@ -9,7 +9,7 @@ namespace Morpheus
     public partial class TandemMassSpectra
     {
         private const PrecursorMassType PRECURSOR_MASS_TYPE = PrecursorMassType.Monoisotopic;
-        private const bool GET_PRECURSOR_MZ_AND_INTENSITY_FROM_MS1 = true;
+        private const bool REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1 = true;
         private const bool ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE = false;
 
         public void Load(string rawFilepath, int minimumAssumedPrecursorChargeState, int maximumAssumedPrecursorChargeState,
@@ -17,7 +17,7 @@ namespace Morpheus
             bool assignChargeStates, bool deisotope, MassTolerance isotopicMZTolerance, int maximumThreads)
         {
             Load(rawFilepath, minimumAssumedPrecursorChargeState, maximumAssumedPrecursorChargeState,
-                absoluteThreshold, relativeThresholdPercent, maximumNumberOfPeaks, 
+                absoluteThreshold, relativeThresholdPercent, maximumNumberOfPeaks,
                 assignChargeStates, maximumThreads);
         }
 
@@ -27,13 +27,13 @@ namespace Morpheus
         {
             OnReportTaskWithoutProgress(new EventArgs());
 
-            IXRawfile2 raw = (IXRawfile2)new MSFileReader_XRawfile();
+            IXRawfile5 raw = (IXRawfile5)new MSFileReader_XRawfile();
 
             raw.Open(rawFilepath);
             raw.SetCurrentController(0, 1);
 
             Dictionary<int, double[,]> ms1s;
-            if(GET_PRECURSOR_MZ_AND_INTENSITY_FROM_MS1)
+            if(REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
             {
                 ms1s = new Dictionary<int, double[,]>();
             }
@@ -51,68 +51,71 @@ namespace Morpheus
             ParallelOptions parallel_options = new ParallelOptions();
             parallel_options.MaxDegreeOfParallelism = maximumThreads;
             Parallel.For(first_scan_number, last_scan_number + 1, scan_number =>
+            {
+                // ref parameter initializations
+                string scan_filter = null;
+                int MSOrder = -1;
+
+                raw.GetFilterForScanNum(scan_number, ref scan_filter);
+                raw.GetMSOrderForScanNum(scan_number, ref MSOrder);
+                if (MSOrder > 1)
                 {
-                    string scan_filter = null;
-                    raw.GetFilterForScanNum(scan_number, ref scan_filter);
+                    string spectrum_id = "controllerType=0 controllerNumber=1 scan=" + scan_number.ToString();
 
-                    if(!scan_filter.Contains(" ms "))
+                    double retention_time_minutes = double.NaN;
+                    raw.RTFromScanNum(scan_number, ref retention_time_minutes);
+
+                    int polarity = DeterminePolarity(scan_filter);
+
+                    string fragmentation_method = GetFragmentationMethod(scan_filter);
+
+                    double precursor_mz;
+                    double precursor_intensity;
+                    GetPrecursor(ms1s, raw, scan_number, scan_filter, first_scan_number, out precursor_mz, out precursor_intensity);
+
+                    int charge = DeterminePrecursorCharge(raw, scan_number);
+                    if(polarity < 0)
                     {
-                        string spectrum_id = "controllerType=0 controllerNumber=1 scan=" + scan_number.ToString();
+                        charge = -charge;
+                    }
 
-                        double retention_time_minutes = double.NaN;
-                        raw.RTFromScanNum(scan_number, ref retention_time_minutes);
+                    double[,] label_data = GetFragmentationData(raw, scan_number, scan_filter);
+                    List<MSPeak> peaks = new List<MSPeak>(label_data.GetLength(1));
+                    for(int peak_index = label_data.GetLowerBound(1); peak_index <= label_data.GetUpperBound(1); peak_index++)
+                    {
+                        peaks.Add(new MSPeak(label_data[(int)RawLabelDataColumn.MZ, peak_index],
+                            label_data[(int)RawLabelDataColumn.Intensity, peak_index],
+                            assignChargeStates && (int)RawLabelDataColumn.Charge < label_data.GetLength(0) ? (int)label_data[(int)RawLabelDataColumn.Charge, peak_index] : 0, polarity));
+                    }
 
-                        int polarity = DeterminePolarity(scan_filter);
-
-                        string fragmentation_method = GetFragmentationMethod(scan_filter);
-
-                        double precursor_mz;
-                        double precursor_intensity;
-                        GetPrecursor(ms1s, raw, scan_number, scan_filter, first_scan_number, out precursor_mz, out precursor_intensity);
-
-                        int charge = DeterminePrecursorCharge(raw, scan_number);
-                        if(polarity < 0)
+                    peaks = FilterPeaks(peaks, absoluteThreshold, relativeThresholdPercent, maximumNumberOfPeaks);
+                    if(peaks.Count > 0)
+                    {
+                        for(int c = (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? minimumAssumedPrecursorChargeState : charge);
+                            c <= (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? maximumAssumedPrecursorChargeState : charge); c++)
                         {
-                            charge = -charge;
-                        }
+                            double precursor_mass = MSPeak.MassFromMZ(precursor_mz, c);
 
-                        double[,] label_data = GetFragmentationData(raw, scan_number, scan_filter);
-                        List<MSPeak> peaks = new List<MSPeak>(label_data.GetLength(1));
-                        for(int peak_index = label_data.GetLowerBound(1); peak_index <= label_data.GetUpperBound(1); peak_index++)
-                        {
-                            peaks.Add(new MSPeak(label_data[(int)RawLabelDataColumn.MZ, peak_index],
-                                label_data[(int)RawLabelDataColumn.Intensity, peak_index],
-                                assignChargeStates && (int)RawLabelDataColumn.Charge < label_data.GetLength(0) ? (int)label_data[(int)RawLabelDataColumn.Charge, peak_index] : 0, polarity));
-                        }
-
-                        peaks = FilterPeaks(peaks, absoluteThreshold, relativeThresholdPercent, maximumNumberOfPeaks);
-                        if(peaks.Count > 0)
-                        {
-                            for(int c = (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? minimumAssumedPrecursorChargeState : charge);
-                                c <= (ALWAYS_USE_PRECURSOR_CHARGE_STATE_RANGE || charge == 0 ? maximumAssumedPrecursorChargeState : charge); c++)
+                            TandemMassSpectrum spectrum = new TandemMassSpectrum(rawFilepath, scan_number, spectrum_id, null, retention_time_minutes, fragmentation_method, precursor_mz, precursor_intensity, c, precursor_mass, peaks);
+                            lock(this)
                             {
-                                double precursor_mass = MSPeak.MassFromMZ(precursor_mz, c);
-
-                                TandemMassSpectrum spectrum = new TandemMassSpectrum(rawFilepath, scan_number, spectrum_id, null, retention_time_minutes, fragmentation_method, precursor_mz, precursor_intensity, c, precursor_mass, peaks);
-                                lock(this)
-                                {
-                                    Add(spectrum);
-                                }
+                                Add(spectrum);
                             }
                         }
                     }
+                }
 
-                    lock(progress_lock)
+                lock(progress_lock)
+                {
+                    spectra_processed++;
+                    int new_progress = (int)((double)spectra_processed / (last_scan_number - first_scan_number + 1) * 100);
+                    if(new_progress > old_progress)
                     {
-                        spectra_processed++;
-                        int new_progress = (int)((double)spectra_processed / (last_scan_number - first_scan_number + 1) * 100);
-                        if(new_progress > old_progress)
-                        {
-                            OnUpdateProgress(new ProgressEventArgs(new_progress));
-                            old_progress = new_progress;
-                        }
+                        OnUpdateProgress(new ProgressEventArgs(new_progress));
+                        old_progress = new_progress;
                     }
                 }
+            }
             );
 
             raw.Close();
@@ -155,7 +158,7 @@ namespace Morpheus
             }
         }
 
-        private static void GetPrecursor(IDictionary<int, double[,]> ms1s, IXRawfile2 raw, int scanNumber, string scanFilter, int firstScanNumber, out double mz, out double intensity)
+        private static void GetPrecursor(IDictionary<int, double[,]> ms1s, IXRawfile5 raw, int scanNumber, string scanFilter, int firstScanNumber, out double mz, out double intensity)
         {
             if(PRECURSOR_MASS_TYPE == PrecursorMassType.Isolation)
             {
@@ -163,11 +166,12 @@ namespace Morpheus
             }
             else if(PRECURSOR_MASS_TYPE == PrecursorMassType.Monoisotopic)
             {
-                mz = GetMonoisotopicMZ(raw, scanNumber, scanFilter);
+                mz = -1;
+                raw.GetPrecursorMassForScanNum(scanNumber, 2, ref mz);
             }
-            if(GET_PRECURSOR_MZ_AND_INTENSITY_FROM_MS1)
+            if(REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1)
             {
-                GetAccurateMZAndIntensity(ms1s, raw, scanNumber, firstScanNumber, ref mz, out intensity);
+                RefineMZestimateAndGetIntensity(ms1s, raw, scanNumber, firstScanNumber, ref mz, out intensity);
             }
             else
             {
@@ -175,15 +179,21 @@ namespace Morpheus
             }
         }
 
-        private static bool GetAccurateMZAndIntensity(IDictionary<int, double[,]> ms1s, IXRawfile2 raw, int scanNumber, int firstScanNumber, ref double mz, out double intensity)
+        // For a given MSn scan, determines the precursor mz and intensity by looking at the scans backwards until an MS1 scan is found
+        // In the found MS1 scan, look for peak with similar mass/charge to the input parameter mz
+        // Return that peak in variables mz and intensity
+        private static bool RefineMZestimateAndGetIntensity(IDictionary<int, double[,]> ms1s, IXRawfile5 raw, int scanNumber, int firstScanNumber, ref double mz, out double intensity)
         {
             scanNumber--;
             while(scanNumber >= firstScanNumber)
             {
+                // ref parameter initializations
                 string scan_filter = null;
-                raw.GetFilterForScanNum(scanNumber, ref scan_filter);
+                int MSOrder = -1;
 
-                if(scan_filter.Contains(" ms "))
+                raw.GetFilterForScanNum(scanNumber, ref scan_filter);
+                raw.GetMSOrderForScanNum(scanNumber, ref MSOrder);
+                if (MSOrder == 1)
                 {
                     double[,] ms1;
                     lock(ms1s)
@@ -194,6 +204,8 @@ namespace Morpheus
                             {
                                 object labels_obj = null;
                                 object flags_obj = null;
+                                // Read FT-PROFILE labels of a scan
+                                // labels_obj will contain values of mass(double), intensity(double), resolution(float), baseline(float), noise(float) and charge(int).
                                 raw.GetLabelData(ref labels_obj, ref flags_obj, ref scanNumber);
                                 ms1 = (double[,])labels_obj;
                             }
@@ -202,6 +214,8 @@ namespace Morpheus
                                 double centroid_peak_width = double.NaN;
                                 object mass_list = null;
                                 object peak_flags = null;
+                                // Only applicable to scanning devices such as MS and PDA
+                                // mass_list will containan array of double precision values in mass intensity pairs in ascending mass order
                                 int array_size = -1;
                                 raw.GetMassListFromScanNum(scanNumber, null, 0, 0, 0, 1, ref centroid_peak_width, ref mass_list, ref peak_flags, ref array_size);
                                 ms1 = (double[,])mass_list;
@@ -211,6 +225,7 @@ namespace Morpheus
                     }
 
                     int index = -1;
+                    // In the MS1 scan, look at every peak. Find index of the one that is closest in mz value to the input parameter mz
                     for(int i = ms1.GetLowerBound(1); i <= ms1.GetUpperBound(1); i++)
                     {
                         if(index < 0 || Math.Abs(ms1[0, i] - mz) < Math.Abs(ms1[0, index] - mz))
@@ -306,32 +321,6 @@ namespace Morpheus
             return isolation_mz;
         }
 
-        private static double GetMonoisotopicMZ(IXRawfile2 raw, int scanNumber, string scanFilter)
-        {
-            object labels_obj = null;
-            object values_obj = null;
-            int array_size = -1;
-            raw.GetTrailerExtraForScanNum(scanNumber, ref labels_obj, ref values_obj, ref array_size);
-            string[] labels = (string[])labels_obj;
-            string[] values = (string[])values_obj;
-            for(int i = labels.GetLowerBound(0); i <= labels.GetUpperBound(0); i++)
-            {
-                if(labels[i].StartsWith("Monoisotopic M/Z"))
-                {
-                    double monoisotopic_mz = double.Parse(values[i], CultureInfo.InvariantCulture);
-                    if(monoisotopic_mz > 0.0)
-                    {
-                        return monoisotopic_mz;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return GetIsolationMZ(scanFilter);
-        }
     }
 
     internal enum PrecursorMassType


### PR DESCRIPTION
Improve precursor mz determination and improve readability. Now even with REFINE_PRECURSOR_MZ_AND_GET_INTENSITY_FROM_MS1 = false still have very accurate precursor mz read from the raw file.
Fix indentation.
