### PR TITLE
Fix peptide spectrum scoring

### DIFF
--- a/Morpheus/Morpheus/PeptideSpectrumMatch.cs
+++ b/Morpheus/Morpheus/PeptideSpectrumMatch.cs
@@ -138,7 +138,8 @@ namespace Morpheus
             {
                 return comparison;
             }
-            comparison = Math.Abs(left.PrecursorMassErrorDa).CompareTo(Math.Abs(right.PrecursorMassErrorDa));
+            if (Math.Abs(left.PrecursorMassErrorDa)<=0.5)
+                comparison = Math.Abs(left.PrecursorMassErrorDa).CompareTo(Math.Abs(right.PrecursorMassErrorDa));
             if (comparison != 0)
             {
                 return comparison;


### PR DESCRIPTION
Only allow lower mass error replacement if it is a match. 
Excluding case of mass error 100 daltons on 
PEPTIDE
with optional phosphorylation on T. 
We would rather it not assign any PTM in this case, instead of assigning this phosphorylation, even though it decreases mass error.
